### PR TITLE
Fix missing math lib and update OpenBSD build & sndiod configuration in README

### DIFF
--- a/Makefile.bsd-wrapper
+++ b/Makefile.bsd-wrapper
@@ -11,7 +11,7 @@ PCCF!=	pkg-config --cflags ${LIBS}
 CFLAGS+=${PCCF}
 
 PCLA!=	pkg-config --libs ${LIBS}
-LDADD+=	${PCLA} -lsndio
+LDADD+=	${PCLA} -lm -lsndio
 
 DEBUG+=	-Wall
 NOMAN=

--- a/README.md
+++ b/README.md
@@ -6,7 +6,24 @@ Visualisation hack for OpenBSD (sndio) and Linux (alsa) playback.
 
 ## OpenBSD
 
-`sndiod` must be started in monitoring mode: `sndiod -m play,mon,midi`
+Install required packages:
+
+```
+pkg_add fftw3
+```
+
+Build:
+
+```
+make -f Makefile.bsd-wrapper
+```
+
+`sndiod` must be started in monitoring mode (see the [Multimedia: Recording a Monitor Mix of All Audio Playback](https://www.openbsd.org/faq/faq13.html#recordmon) section of the FAQ:)
+
+```
+rcctl set sndiod flags -s default -m play,mon -s mon
+rcctl restart sndiod
+```
 
 ## Linux
 


### PR DESCRIPTION
This resolves the linking errors under OpenBSD amd64/7.5-stable described in Issue #3 by updating `Makefile.bsd-wrapper` to add `-lm` to the `LDADD` make variable.

I also took this opportunity to update the README's OpenBSD instructions to:

* Note required packages to install
* Document building using `Makefile.bsd-wrapper`
* Configure `sndiod` for mix monitoring using `rcctl` as suggested in the OpenBSD FAQ